### PR TITLE
feat(categories): update category seeder names and image URLs

### DIFF
--- a/src/database/seeders/categories/categories.seeder.service.ts
+++ b/src/database/seeders/categories/categories.seeder.service.ts
@@ -46,21 +46,21 @@ export class CategoriesSeederService implements Seeder {
       this.logger.log('Creando subcategorías de ropa...');
       // Subcategorías de ropa
       const ropaHombreData = categoryFactory.generate({
-        name: 'Ropa de Hombre',
+        name: 'Hombre',
         slug: 'ropa-hombre',
         parent: savedRopa,
         image:
-          'https://images.unsplash.com/photo-1617137968427-85924c800a22?w=800',
+          'https://res.cloudinary.com/dg2ugi96k/image/upload/v1747863717/ropa-man_f1k5y6.png',
       });
       const ropaMujerData = categoryFactory.generate({
-        name: 'Ropa de Mujer',
+        name: 'Mujer',
         slug: 'ropa-mujer',
         parent: savedRopa,
         image:
-          'https://images.unsplash.com/photo-1581044777550-4cfa60707c03?w=800',
+          'https://res.cloudinary.com/dg2ugi96k/image/upload/v1747902712/ropa-woman_anqyvl.png',
       });
       const ropaNinoData = categoryFactory.generate({
-        name: 'Ropa de Niño',
+        name: 'Niño',
         slug: 'ropa-nino',
         parent: savedRopa,
         image:

--- a/src/models/categories/repositories/categories.repository.ts
+++ b/src/models/categories/repositories/categories.repository.ts
@@ -159,6 +159,7 @@ export class CategoriesRepository extends ModelRepository<
     // Actualizar name y slug si están presentes en data
     if (data.name !== undefined) category.name = data.name;
     if (data.slug !== undefined) category.slug = data.slug;
+    if (data.image !== undefined) category.image = data.image;
 
     // Manejar cambio de padre por separado
     if (parentId !== undefined) {


### PR DESCRIPTION
- ✨ Category seeder updates:
  - Rename clothing subcategories to:
    - 'Men'
    - 'Women'
    - 'Kids'
  - Update image URLs for clothing subcategories
    - New CDN sources
    - Higher resolution images
- 🔄 Repository enhancements:
  - Add 'image' property handling in:
    - Category updates
    - Bulk operations